### PR TITLE
first commit

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -105,6 +105,9 @@ if (in_spark):
 _minimum_pandas_version = "0.19.2"
 _minimum_pyarrow_version = "0.8.0"
 
+# used to provided consistent hash accros python interpreter
+_minimum_mmh3_version = "2.5.1"
+
 try:
     # We copy the shell script to be under pyspark/python/pyspark so that the launcher scripts
     # find it where expected. The rest of the files aren't copied because they are accessed


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use murmurhash instead of python built-in `hash` function.
`hash` produces different hash between python2 and python3
```
Python 2.7.13 (ab0b9caf307db6592905a80b8faffd69b39005b8, Sep 30 2018, 13:49:36)
[PyPy 6.0.0 with GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> hash("kiss my hash")
9039188552751381472
Python 3.5.3 (fdd60ed87e94, Apr 24 2018, 06:10:18)
[PyPy 6.0.0 with GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> hash("kiss my hash")
-7762818341272944931
```
`hash` produces different hash between 2 different instances of python3 
```
Python 3.5.3 (fdd60ed87e94, Apr 24 2018, 06:10:18)
[PyPy 6.0.0 with GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> hash("kiss my hash")
-7762818341272944931
>>>> exit()
➜  bin ./pypy3
Python 3.5.3 (fdd60ed87e94, Apr 24 2018, 06:10:18)
[PyPy 6.0.0 with GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> hash("kiss my hash")
-1601376979952937050
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
